### PR TITLE
Add score metadata to evaluation scorer

### DIFF
--- a/inspect_weave/hooks.py
+++ b/inspect_weave/hooks.py
@@ -40,8 +40,11 @@ class WeaveEvaluationHooks(Hooks):
         )
         if data.sample.scores is not None:
             for k,v in data.sample.scores.items():
-                sample_score_logger.log_score(
-                    scorer=k,
+                scorer_object = {
+                    "name": k,
+                } | v.metadata if v.metadata is not None else {}
+                sample_score_logger.log_score( # TODO: could we use the async method here?
+                    scorer=scorer_object,
                     score=v.value if not isinstance(v.value, str) and not isinstance(v.value, list) else {"score": str(v.value)}  # TODO: handle different score return types
                  )
             sample_score_logger.finish()


### PR DESCRIPTION
Weave doesn't explicitly allow score metadata, but the scorer object passed to `log_score` can take a dict of attributes, which we can use to pass the metadata to Weave. This can be useful for breaking down eval results into categories, for example.