### PR TITLE
Handle categories explicitly in scorer metadata

### DIFF
--- a/hellaswag.py
+++ b/hellaswag.py
@@ -1,8 +1,10 @@
 from inspect_ai import Task, task
 from inspect_ai.dataset import Sample, hf_dataset
-from inspect_ai.scorer import choice
+from inspect_ai.scorer import choice, scorer, accuracy, stderr, Score
+from inspect_ai.solver._task_state import TaskState, Target
 from inspect_ai.solver import multiple_choice, system_message
 from dotenv import load_dotenv
+
 
 load_dotenv()
 
@@ -19,6 +21,30 @@ def record_to_sample(record):
             source_id=record["source_id"]
         )
     )
+
+@scorer(metrics=[accuracy(), stderr()])
+def includes(ignore_case: bool = True):
+
+    async def score(state: TaskState, target: Target):
+
+        # check for correct
+        answer = state.output.completion
+        target = target.text
+        if ignore_case:
+            correct = answer.lower().rfind(target.lower()) != -1
+        else:
+            correct = answer.rfind(target) != -1
+
+        # return score
+        return Score(
+            value = 1 if correct else 0,
+            answer=answer,
+            metadata={
+                "test": "test"
+            }
+        )
+
+    return score
 
 @task
 def hellaswag():
@@ -38,5 +64,5 @@ def hellaswag():
           system_message(SYSTEM_MESSAGE),
           multiple_choice()
         ],
-        scorer=choice(),
+        scorer=includes(),
     )

--- a/inspect_weave/hooks.py
+++ b/inspect_weave/hooks.py
@@ -40,13 +40,15 @@ class WeaveEvaluationHooks(Hooks):
         )
         if data.sample.scores is not None:
             for k,v in data.sample.scores.items():
-                scorer_object = {
-                    "name": k,
-                } | v.metadata if v.metadata is not None else {}
                 sample_score_logger.log_score( # TODO: could we use the async method here?
-                    scorer=scorer_object,
+                    scorer=k,
                     score=v.value if not isinstance(v.value, str) and not isinstance(v.value, list) else {"score": str(v.value)}  # TODO: handle different score return types
                  )
+                if v.metadata is not None and "category" in v.metadata:
+                    sample_score_logger.log_score(
+                        scorer=f"{k}_{v.metadata['category']}",
+                        score=v.value if not isinstance(v.value, str) and not isinstance(v.value, list) else {"score": str(v.value)}
+                    )
             sample_score_logger.finish()
 
     def enabled(self) -> bool:


### PR DESCRIPTION
Weave doesn't natively support scoring metadata in the way we would like, so for now lets catch the "category" metadata tag explicitly and re-log scores per category for aggregation purposes
