### PR TITLE
Handle unfinalised EvaluationLogger

### DIFF
--- a/inspect_weave/hooks.py
+++ b/inspect_weave/hooks.py
@@ -17,12 +17,19 @@ class WeaveEvaluationHooks(Hooks):
         weave.init(os.environ["WEAVE_PROJECT_NAME"])    
 
     async def on_run_end(self, data: RunEnd) -> None:
+        if self.weave_eval_logger is not None:
+            if not self.weave_eval_logger._is_finalized:
+                self.weave_eval_logger.finish()
         weave.finish()
 
     async def on_task_start(self, data: TaskStart) -> None:
         model_name = format_model_name(data.spec.model) 
         evaluation_name = f"{data.spec.task}_{data.spec.run_id}"
-        self.weave_eval_logger = weave.EvaluationLogger(name=evaluation_name, dataset=data.spec.dataset.name or "test_dataset", model=model_name)
+        self.weave_eval_logger = weave.EvaluationLogger(
+            name=evaluation_name,
+            dataset=data.spec.dataset.name or "test_dataset", # TODO: set a default dataset name
+            model=model_name
+        )
 
     async def on_task_end(self, data: TaskEnd) -> None:
         assert self.weave_eval_logger is not None

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,9 @@ exclude = build/
 
 # Uncomment the following line if you need to ignore missing imports for external packages
 # ignore_missing_imports = true
+
+[mypy-weave.*]
+ignore_missing_imports = true
+
+[mypy-inspect_ai.*]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,8 @@ packages = [
 
 [project.entry-points.inspect_ai]
 inspect_weave = "inspect_weave._registry"
+
+[tool.ruff]
+exclude = [
+    "inspect_weave/_registry.py"
+]


### PR DESCRIPTION
`EvaluationLogger` is sometimes unfinalised if Inspect errors, which can cause a Weave exception to appear that is unrelated to the root cause and potentially misleading. This PR handles cleaning up unfinalised loggers during error states.