### PR TITLE
Pin weave dependency

### DIFF
--- a/inspect_weave/hooks.py
+++ b/inspect_weave/hooks.py
@@ -3,8 +3,8 @@ import os
 
 from inspect_ai.hooks import Hooks, RunEnd, RunStart, SampleEnd, hooks, TaskStart, TaskEnd
 import weave
-from inspect_weave.utils import format_model_name, format_score_types
 from weave.trace.settings import UserSettings
+from inspect_weave.utils import format_model_name, format_score_types
 
 @hooks(name="weave_evaluation_hooks", description="Integration hooks for writing evaluation results to Weave")
 class WeaveEvaluationHooks(Hooks):
@@ -20,7 +20,7 @@ class WeaveEvaluationHooks(Hooks):
             settings=UserSettings(
                 print_call_link=False
             )
-        )    
+        )
 
     async def on_run_end(self, data: RunEnd) -> None:
         if self.weave_eval_logger is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
   "inspect_ai @ git+https://github.com/UKGovernmentBEIS/inspect_ai.git",
-  "weave",
+  "weave==0.51.54",
   "httpx[socks]",
 ]
 


### PR DESCRIPTION
Since upgrading from 0.51.54 model API calls are not being instrumented properly... need to dig into why that is happening, but for now lets pin the dep to workaround