### PR TITLE
Add unit tests for hook logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+import pytest
+import configparser
+import os
+from typing import Callable
+from pathlib import Path
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import exact
+from inspect_ai.solver import generate
+from inspect_ai import eval as inspect_eval
+from inspect_ai.log import EvalLog
+from unittest.mock import MagicMock
+from weave import EvaluationLogger
+from inspect_weave.hooks import WeaveEvaluationHooks
+import inspect_ai.hooks._startup as hooks_startup_module
+from unittest.mock import patch
+from inspect_weave.providers import weave_evaluation_hooks
+
+
+@pytest.fixture(scope="function")
+def weave_evaluation_hooks_with_mocked_client_deps():
+    with (
+        patch("inspect_weave.hooks.weave.init", MagicMock()) as weave_init,
+        patch("inspect_weave.hooks.weave.finish", MagicMock()) as weave_finish,
+        patch("inspect_weave.hooks.weave.EvaluationLogger", MagicMock(spec=EvaluationLogger)) as weave_evaluation_logger
+    ):
+        yield weave_evaluation_hooks(), weave_init, weave_finish, weave_evaluation_logger
+
+@pytest.fixture(scope="function")
+def register_hooks_for_testing(weave_evaluation_hooks_with_mocked_client_deps: tuple[WeaveEvaluationHooks, MagicMock, MagicMock, MagicMock]) -> dict[str, MagicMock]:
+    """
+    Override hook registration to ensure we are testing latest version of the package.
+    """
+    hooks_startup_module._load_registry_hooks = MagicMock(return_value=[weave_evaluation_hooks_with_mocked_client_deps[0]])
+    hooks_startup_module._format_hook_for_printing = MagicMock(return_value="[bold]WeaveEvaluationHooks[/bold]: Integration hooks for writing evaluation results to Weave")
+
+    return {
+        "weave_init": weave_evaluation_hooks_with_mocked_client_deps[1],
+        "weave_finish": weave_evaluation_hooks_with_mocked_client_deps[2],
+        "weave_evaluation_logger": weave_evaluation_hooks_with_mocked_client_deps[3]
+    }
+
+@pytest.fixture(scope="function")
+def inspect_eval_and_weave_mocks(register_hooks_for_testing: dict[str, MagicMock]) -> dict[str, Callable[[], list[EvalLog]] | MagicMock]:
+    """
+    Returns a function that can be called to run an inspect eval.
+    """
+    @task
+    def hello_world():
+        return Task(
+            dataset=[
+                Sample(
+                    input="Just reply with Hello World",
+                    target="Hello World",
+                )
+            ],
+            solver=[generate()],
+            scorer=exact(),
+        )
+
+    return {
+        "inspect_eval": lambda: inspect_eval(hello_world, model="mockllm/model"),
+    } | register_hooks_for_testing
+
+@pytest.fixture(scope="function")
+def initialise_wandb(tmp_path: Path) -> None:
+    """
+    Writes a wandb settings file to the tmp_path directory, and changes the current working directory to the tmp_path.
+    """
+    config = configparser.ConfigParser()
+    config["default"] = {
+        "entity": "test-entity",
+        "project": "test-project"
+    }
+    os.makedirs(tmp_path / "wandb")
+    with open(tmp_path / "wandb" / "settings", "w") as f:
+        config.write(f)
+    os.chdir(tmp_path)
+
+

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -4,7 +4,7 @@ import configparser
 import os
 from pathlib import Path
 from unittest.mock import MagicMock
-from inspect_ai.hooks import SampleEnd
+from inspect_ai.hooks import SampleEnd, TaskEnd
 from inspect_ai.model import ChatCompletionChoice, ModelOutput, ChatMessageAssistant
 from inspect_ai.log import EvalSample
 from inspect_weave.hooks import WeaveEvaluationHooks
@@ -79,6 +79,22 @@ class TestWeaveEvaluationHooks:
             dataset="test_dataset",
             model="mockllm__model"
         )
+
+    @pytest.mark.asyncio
+    async def test_weave_evaluation_logger_finish_called_on_task_end(self) -> None:
+        # Given
+        hooks = WeaveEvaluationHooks()
+        hooks.weave_eval_logger = MagicMock(spec=weave.EvaluationLogger)
+
+        # When
+        await hooks.on_task_end(TaskEnd(
+            run_id="test_run_id",
+            eval_id="test_eval_id",
+            log=MagicMock(spec=EvalLog)
+        ))
+
+        # Then
+        hooks.weave_eval_logger.finish.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_writes_eval_score_to_weave_on_sample_end(self) -> None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,118 @@
+from inspect_ai.log import EvalLog
+from typing import Callable
+import configparser
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+from inspect_ai.hooks import SampleEnd
+from inspect_ai.model import ChatCompletionChoice, ModelOutput, ChatMessageAssistant
+from inspect_ai.log import EvalSample
+from inspect_weave.hooks import WeaveEvaluationHooks
+from inspect_ai.scorer import Score
+import pytest
+import weave
+
+class TestWeaveEvaluationHooks:
+
+    def test_weave_init_not_called_on_run_start_when_disabled(self, inspect_eval_and_weave_mocks: dict[str, Callable[[], list[EvalLog]] | MagicMock], tmp_path: Path) -> None:
+
+        # Given
+        config = configparser.ConfigParser()
+        config["default"] = {
+            "entity": "test-entity",
+            "project": "test-project",
+            "mode": "disabled"
+        }
+        os.makedirs(tmp_path / "wandb")
+        with open(tmp_path / "wandb" / "settings", "w") as f:
+            config.write(f)
+        os.chdir(tmp_path)
+
+        # When
+
+        inspect_eval = inspect_eval_and_weave_mocks["inspect_eval"]
+        weave_init = inspect_eval_and_weave_mocks["weave_init"]
+        inspect_eval()
+
+        # Then
+        assert isinstance(weave_init, MagicMock)
+        weave_init.assert_not_called()
+
+    def test_weave_init_called_on_run_start(self, inspect_eval_and_weave_mocks: dict[str, Callable[[], list[EvalLog]] | MagicMock], initialise_wandb: None) -> None:
+        # Given
+        inspect_eval = inspect_eval_and_weave_mocks["inspect_eval"]
+        weave_init = inspect_eval_and_weave_mocks["weave_init"]
+
+        # When
+        inspect_eval()
+
+        # Then
+        assert isinstance(weave_init, MagicMock)
+        weave_init.assert_called_once()
+
+    def test_weave_finish_called_on_run_end(self, inspect_eval_and_weave_mocks: dict[str, Callable[[], list[EvalLog]] | MagicMock], initialise_wandb: None) -> None:
+        # Given
+        inspect_eval = inspect_eval_and_weave_mocks["inspect_eval"]
+        weave_finish = inspect_eval_and_weave_mocks["weave_finish"]
+
+        # When
+        inspect_eval()
+
+        # Then
+        assert isinstance(weave_finish, MagicMock)
+        weave_finish.assert_called_once()
+
+    def test_weave_evaluation_logger_created_on_task_start(self, inspect_eval_and_weave_mocks: dict[str, Callable[[], list[EvalLog]] | MagicMock], initialise_wandb: None) -> None:
+        # Given
+        inspect_eval = inspect_eval_and_weave_mocks["inspect_eval"]
+        weave_evaluation_logger = inspect_eval_and_weave_mocks["weave_evaluation_logger"]
+
+        # When
+        eval_logs = inspect_eval()
+
+        # Then
+        assert isinstance(weave_evaluation_logger, MagicMock)
+        assert len(eval_logs) == 1
+        run_id = eval_logs[0].eval.run_id
+        weave_evaluation_logger.assert_called_once_with(
+            name=f"hello_world_{run_id}",
+            dataset="test_dataset",
+            model="mockllm__model"
+        )
+
+    @pytest.mark.asyncio
+    async def test_writes_eval_score_to_weave_on_sample_end(self) -> None:
+        # Given
+        hooks = WeaveEvaluationHooks()
+        sample = SampleEnd(
+            run_id="test_run_id",
+            eval_id="test_eval_id",
+            sample_id="test_sample_id",
+            sample=EvalSample(
+                id=1,
+                epoch=1,
+                input="test_input",
+                target="test_output",
+                scores={"test_score": Score(value=1.0)},
+                output=ModelOutput(model="mockllm/model", choices=[ChatCompletionChoice(message=ChatMessageAssistant(content="test_output"))])
+            )
+        )
+
+        mock_weave_eval_logger = MagicMock(spec=weave.EvaluationLogger)
+        mock_score_logger = MagicMock(spec=weave.flow.eval_imperative.ScoreLogger)
+        mock_weave_eval_logger.log_prediction.return_value = mock_score_logger
+        hooks.weave_eval_logger = mock_weave_eval_logger
+
+        # When
+        await hooks.on_sample_end(sample)
+
+        # Then
+        mock_weave_eval_logger.log_prediction.assert_called_once_with(
+            inputs={"input": "test_input"},
+            output="test_output"
+        )
+        mock_score_logger.log_score.assert_called_once_with(
+            scorer="test_score",
+            score=1.0
+        )
+        mock_score_logger.finish.assert_called_once()


### PR DESCRIPTION
I've added a set of unit tests to test the existing hook logic. I've taken two approaches to try and make these tests as useful as possible - some tests directly test the logic on toy objects, and some test that various Weave methods get called correctly during a mock Inspect eval run. Probably we should favour the former for unit tests, and use the latter almost like integration tests, but we can iterate on test structure as we go.