### PR TITLE
Convert boolean scorers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: ruff
         name: Ruff linter
-        entry: ruff check .
+        entry: ruff check inspect_weave tests
         language: python
         types: [python]
         pass_filenames: false

--- a/inspect_weave/hooks.py
+++ b/inspect_weave/hooks.py
@@ -42,7 +42,7 @@ class WeaveEvaluationHooks(Hooks):
 
     async def on_task_end(self, data: TaskEnd) -> None:
         assert self.weave_eval_logger is not None
-        summary = {}
+        summary: dict[str, dict[str, dict[int, float]]] = {}
         if data.log and data.log.results:
             for score in data.log.results.scores:
                 scorer_name = score.name

--- a/inspect_weave/hooks.py
+++ b/inspect_weave/hooks.py
@@ -42,7 +42,16 @@ class WeaveEvaluationHooks(Hooks):
 
     async def on_task_end(self, data: TaskEnd) -> None:
         assert self.weave_eval_logger is not None
-        self.weave_eval_logger.log_summary()
+        summary = {}
+        if data.log and data.log.results:
+            for score in data.log.results.scores:
+                scorer_name = score.name
+                if score.metrics:
+                    summary[scorer_name] = {}
+                    for metric_name, metric in score.metrics.items():
+                        summary[scorer_name][metric_name] = metric.value
+                        
+        self.weave_eval_logger.log_summary(summary)
         self.weave_eval_logger.finish()
 
     async def on_sample_end(self, data: SampleEnd) -> None:

--- a/inspect_weave/utils.py
+++ b/inspect_weave/utils.py
@@ -13,6 +13,10 @@ def format_model_name(model_name: str) -> str:
 
 def format_score_types(score_value: Value) -> ScoreType:
     if isinstance(score_value, str):
+        if score_value == "C":
+            return {"score": True}
+        elif score_value == "I":
+            return {"score": False}
         return {"score": score_value}
     elif isinstance(score_value, int):
         return float(score_value)

--- a/inspect_weave/utils.py
+++ b/inspect_weave/utils.py
@@ -13,10 +13,6 @@ def format_model_name(model_name: str) -> str:
 
 def format_score_types(score_value: Value) -> ScoreType:
     if isinstance(score_value, str):
-        if score_value == "C":
-            return {"score": True}
-        elif score_value == "I":
-            return {"score": False}
         return {"score": score_value}
     elif isinstance(score_value, int):
         return float(score_value)


### PR DESCRIPTION
Inspect uses "C" and "I" when using the `match` scorer but this is preventing the auto-summarization from aggregating them correctly. There might be a better solution to this but in this PR, I convert them to boolean True of False which is more typical to how Weave expects it.

What do you think about this implementation? 