### PR TITLE
fix module missing error: use auto-discovery for packages in setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,9 @@ Issues = "https://github.com/DanielPolatajko/inspect_weave/issues"
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = [
-    "inspect_weave"
-]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["inspect_weave*"]
 
 [project.entry-points.inspect_ai]
 inspect_weave = "inspect_weave._registry"


### PR DESCRIPTION
## Describe your changes
Replace hardcoded package list with setuptools.packages.find to automatically discover all inspect_weave subpackages. This fixes the "No module named 'inspect_weave.hooks'" error during pip install and ensures future subpackages are automatically included without manual configuration.

## Issue ticket number and link (if applicable)

## Checklist
- [ ] I have run the pre-commit checks
- [ ] I have run the unit tests and they are passing
- [ ] I have performed a self-review of my code
- [ ] I have added unit tests to cover any core logic changes
