### PR TITLE
Replace YAML config with zero-config pyproject.toml approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,20 @@ wandb init
 
 ### Configuration
 
-`inspect_weave` allows you to specify finer-grained configuration by creating an `inspect-weave-settings.yaml` file and placing it in the `wandb` directory (where the settings file is after running `wandb init`). An example file can be found [here](./wandb/inspect-weave-settings.yaml). Available settings include enabling/disabling Weave or Models integrations, specifying the project and entity to write to for both Models and Weave, passing wandb config to the Models API, and specifying files to associated with the Models run.
+`inspect_weave` works out-of-the-box after running `wandb init` - no additional configuration is required! By default, both Weave and Models integrations are enabled, using the project and entity from your wandb settings.
 
-As mentioned above, by default, the integration will use whichever W&B project and entity you specified when running wandb init, unless overridden in the `inspect-weave-settings.yaml`.
+#### Optional Customization
+
+For advanced users who want to customize the behavior, you can add a `[tool.inspect-weave]` section to your project's `pyproject.toml` file:
+
+```toml
+[tool.inspect-weave.weave]
+enabled = true  # Enable/disable Weave integration (default: true)
+
+[tool.inspect-weave.models]
+enabled = false  # Enable/disable Models integration (default: true)
+files = ["config.yaml", "results/"]  # Files to upload with Models run (default: none)
+```
 
 ### Running Inspect with the integration
 
@@ -70,17 +81,17 @@ Once you have performed the above steps, the integration will be enabled for fut
 
 ### Disabling the integration
 
-You can disable the Weave integration by updating the `inspect-weave-settings.yaml` and specifiying `enabled: false` for the relevant API. For example:
+You can disable either integration by adding configuration to your `pyproject.toml`. For example:
 
-```yaml
-models:
-    enabled: true
+```toml
+[tool.inspect-weave.weave]
+enabled = false  # Disable Weave integration
 
-weave:
-    enabled: false
+[tool.inspect-weave.models]  
+enabled = true   # Keep Models integration enabled
 ```
 
-would write data to the models API, but disable the Weave integration.
+This would disable the Weave integration while keeping the Models API integration enabled.
 
 
 ## Development

--- a/inspect_weave/config/settings_loader.py
+++ b/inspect_weave/config/settings_loader.py
@@ -1,7 +1,7 @@
 from inspect_weave.config.settings import WeaveSettings, ModelsSettings, InspectWeaveSettings
 from wandb.old.core import wandb_dir
 from pathlib import Path
-import yaml
+import tomllib
 from logging import getLogger
 from inspect_weave.exceptions import WandBNotInitialisedException
 import configparser
@@ -11,20 +11,72 @@ logger = getLogger(__name__)
 class SettingsLoader:
 
     @classmethod
-    def parse_inspect_weave_settings(cls, settings_path: Path | None = None) -> InspectWeaveSettings:
-        if settings_path is None or not settings_path.exists():
+    def parse_inspect_weave_settings(cls, pyproject_path: Path | None = None) -> InspectWeaveSettings:
+        """
+        Load settings with this priority:
+        1. Always start with wandb settings for entity/project
+        2. Apply any customizations from user's pyproject.toml
+        3. Default to hooks enabled, no files uploaded
+        """
+        # Always get base entity/project from wandb settings
+        try:
             entity, project_name = cls._read_wandb_entity_and_project_name_from_settings()
-            logger.warning(f"Inspect Weave settings file not found, please add a `inspect-weave-settings.yaml` file to the wandb directory if you want to configure the inspect_weave hooks. Proceeding with default settings. Entity: {entity}, Project: {project_name}")
-            return InspectWeaveSettings(
-                weave=WeaveSettings(entity=entity, project=project_name),
-                models=ModelsSettings(entity=entity, project=project_name)
-            )
-        with open(settings_path, "r") as f:
-            settings = yaml.safe_load(f)
+            logger.info(f"Using wandb settings as base: Entity={entity}, Project={project_name}")
+        except Exception as e:
+            logger.error(f"Failed to read wandb settings. Please run 'wandb init' first. Error: {e}")
+            raise
+        
+        # Load any customizations from user's pyproject.toml
+        pyproject_config = cls._load_pyproject_config(pyproject_path)
+        
+        if pyproject_config:
+            logger.info("Found [tool.inspect-weave] configuration in pyproject.toml")
+        else:
+            logger.info("No [tool.inspect-weave] configuration found. Using defaults: both hooks enabled, no files uploaded")
+        
+        # Build settings with defaults + customizations
+        weave_config = pyproject_config.get("weave", {}) if pyproject_config else {}
+        models_config = pyproject_config.get("models", {}) if pyproject_config else {}
+        
         return InspectWeaveSettings(
-            weave=WeaveSettings(**settings["weave"]),
-            models=ModelsSettings(**settings["models"])
+            weave=WeaveSettings(
+                enabled=weave_config.get("enabled", True),  # Default: enabled
+                entity=entity,  # Always from wandb
+                project=project_name  # Always from wandb
+            ),
+            models=ModelsSettings(
+                enabled=models_config.get("enabled", True),  # Default: enabled
+                entity=entity,  # Always from wandb
+                project=project_name,  # Always from wandb
+                files=models_config.get("files")  # Default: None (no files)
+            )
         )
+    
+    @classmethod
+    def _load_pyproject_config(cls, pyproject_path: Path | None = None) -> dict | None:
+        """Load [tool.inspect-weave] section from user's pyproject.toml"""
+        if pyproject_path is None:
+            # Search for pyproject.toml in current directory and parents
+            cwd = Path.cwd()
+            for parent in [cwd, *cwd.parents]:
+                candidate = parent / "pyproject.toml"
+                if candidate.exists():
+                    pyproject_path = candidate
+                    break
+            else:
+                return None
+        
+        if not pyproject_path.exists():
+            return None
+            
+        try:
+            with open(pyproject_path, "rb") as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError) as e:
+            logger.warning(f"Failed to parse pyproject.toml at {pyproject_path}: {e}")
+            return None
+        
+        return data.get("tool", {}).get("inspect-weave")
 
     @staticmethod
     def _read_wandb_entity_and_project_name_from_settings() -> tuple[str, str]:

--- a/inspect_weave/hooks/model_hooks.py
+++ b/inspect_weave/hooks/model_hooks.py
@@ -33,8 +33,7 @@ class WandBModelHooks(Hooks):
 
     @override
     def enabled(self) -> bool:
-        settings_path = Path(wandb_dir()) / "inspect-weave-settings.yaml"
-        self.settings = self.settings or SettingsLoader.parse_inspect_weave_settings(settings_path).models
+        self.settings = self.settings or SettingsLoader.parse_inspect_weave_settings().models
         return self.settings.enabled
 
     @override

--- a/inspect_weave/hooks/model_hooks.py
+++ b/inspect_weave/hooks/model_hooks.py
@@ -38,7 +38,10 @@ class WandBModelHooks(Hooks):
 
     @override
     async def on_run_start(self, data: RunStart) -> None:
-        assert self.settings is not None
+        # Ensure settings are loaded (in case enabled() wasn't called first)
+        if self.settings is None:
+            self.settings = SettingsLoader.parse_inspect_weave_settings().models
+            
         self.run = wandb.init(id=data.run_id, entity=self.settings.entity, project=self.settings.project) 
 
         if self.settings.files:

--- a/inspect_weave/hooks/weave_hooks.py
+++ b/inspect_weave/hooks/weave_hooks.py
@@ -23,7 +23,10 @@ class WeaveEvaluationHooks(Hooks):
 
     @override
     async def on_run_start(self, data: RunStart) -> None:
-        assert self.settings is not None
+        # Ensure settings are loaded (in case enabled() wasn't called first)
+        if self.settings is None:
+            self.settings = SettingsLoader.parse_inspect_weave_settings().weave
+        
         weave.init(
             project_name=self.settings.project,
             settings=UserSettings(

--- a/inspect_weave/hooks/weave_hooks.py
+++ b/inspect_weave/hooks/weave_hooks.py
@@ -10,8 +10,6 @@ from inspect_weave.weave_custom_overrides.custom_evaluation_logger import Custom
 from inspect_weave.exceptions import WeaveEvaluationException
 from weave.trace.context import call_context
 from typing_extensions import override
-from wandb.old.core import wandb_dir
-from pathlib import Path
 
 logger = getLogger(__name__)
 
@@ -94,8 +92,7 @@ class WeaveEvaluationHooks(Hooks):
 
     @override
     def enabled(self) -> bool:
-        settings_path = Path(wandb_dir()) / "inspect-weave-settings.yaml"
-        self.settings = self.settings or SettingsLoader.parse_inspect_weave_settings(settings_path).weave
+        self.settings = self.settings or SettingsLoader.parse_inspect_weave_settings().weave
         return self.settings.enabled
 
     def _get_eval_metadata(self, data: TaskStart) -> dict[str, str | dict[str, Any]]:

--- a/tests/test_models_hooks.py
+++ b/tests/test_models_hooks.py
@@ -1,5 +1,6 @@
 from inspect_weave.hooks.model_hooks import WandBModelHooks
-import pytest
+from inspect_weave.config.settings import ModelsSettings
+from unittest.mock import patch
 
 class TestWandBModelHooks:
     """
@@ -13,12 +14,20 @@ class TestWandBModelHooks:
         hooks = WandBModelHooks()
         assert hooks.enabled()
 
-    @pytest.mark.models_hooks_disabled
     def test_enabled_returns_false_when_settings_are_set_to_false(self) -> None:
         """
         Test that the enabled method returns False when the settings are set to False.
         """
-        hooks = WandBModelHooks()
-        assert not hooks.enabled()
+        # Mock the settings loader to return disabled models settings
+        disabled_settings = ModelsSettings(
+            enabled=False, 
+            entity="test-entity", 
+            project="test-project"
+        )
+        
+        with patch('inspect_weave.hooks.model_hooks.SettingsLoader.parse_inspect_weave_settings') as mock_loader:
+            mock_loader.return_value.models = disabled_settings
+            hooks = WandBModelHooks()
+            assert not hooks.enabled()
 
     

--- a/tests/test_settings_loader.py
+++ b/tests/test_settings_loader.py
@@ -15,8 +15,53 @@ class TestSettingsLoader:
 
     def test_read_wandb_project_name_from_settings_raises_error_if_settings_file_not_found(self, tmp_path: Path) -> None:
         # Given
-        os.chdir(tmp_path)
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
 
+            # When
+            with pytest.raises(WandBNotInitialisedException, match="wandb settings file not found. Please run `wandb init` to set up a project."):
+                SettingsLoader._read_wandb_entity_and_project_name_from_settings()
+        finally:
+            # Restore original working directory to not break other tests
+            os.chdir(original_cwd)
+    
+    def test_parse_settings_defaults_when_no_pyproject_toml(self) -> None:
+        """Test that defaults are used when no pyproject.toml config exists"""
         # When
-        with pytest.raises(WandBNotInitialisedException, match="wandb settings file not found. Please run `wandb init` to set up a project."):
-            SettingsLoader._read_wandb_entity_and_project_name_from_settings()
+        settings = SettingsLoader.parse_inspect_weave_settings()
+        
+        # Then - should use wandb settings with defaults
+        assert settings.weave.enabled is True
+        assert settings.weave.entity == "test-entity"
+        assert settings.weave.project == "test-project"
+        assert settings.models.enabled is True
+        assert settings.models.entity == "test-entity"
+        assert settings.models.project == "test-project"
+        assert settings.models.files is None
+    
+    def test_parse_settings_with_pyproject_toml_customizations(self, tmp_path: Path) -> None:
+        """Test that pyproject.toml customizations override defaults"""
+        # Given - create pyproject.toml with custom settings
+        pyproject_content = """
+[tool.inspect-weave.weave]
+enabled = false
+
+[tool.inspect-weave.models]
+enabled = true
+files = ["config.yaml", "results/"]
+"""
+        pyproject_path = tmp_path / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+        
+        # When
+        settings = SettingsLoader.parse_inspect_weave_settings(pyproject_path)
+        
+        # Then - should use wandb settings with pyproject customizations
+        assert settings.weave.enabled is False  # Customized
+        assert settings.weave.entity == "test-entity"  # From wandb
+        assert settings.weave.project == "test-project"  # From wandb
+        assert settings.models.enabled is True  # Customized
+        assert settings.models.entity == "test-entity"  # From wandb
+        assert settings.models.project == "test-project"  # From wandb
+        assert settings.models.files == ["config.yaml", "results/"]  # Customized


### PR DESCRIPTION
## Describe your changes
Replace complex YAML configuration with streamlined pyproject.toml setup. Works immediately after `wandb init` with optional customization only.

- Always use wandb settings for entity/project (no duplication)
- Optional [tool.inspect-weave] section in user's pyproject.toml
- Default: both hooks enabled, no files uploaded
- Updated hooks, tests, and documentation

## Issue ticket number and link (if applicable)
closes #58 

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
