### PR TITLE
Fix weave hooks with multiple logger instance

### DIFF
--- a/tests/test_weave_hooks.py
+++ b/tests/test_weave_hooks.py
@@ -61,7 +61,7 @@ class TestWeaveEvaluationHooks:
         mock_weave_eval_logger = MagicMock(spec=weave.EvaluationLogger)
         mock_score_logger = MagicMock(spec=weave.flow.eval_imperative.ScoreLogger)
         mock_weave_eval_logger.log_prediction.return_value = mock_score_logger
-        hooks.weave_eval_logger = mock_weave_eval_logger
+        hooks.weave_eval_loggers["test_eval_id"] = mock_weave_eval_logger
 
         # When
         await hooks.on_sample_end(sample)
@@ -98,7 +98,7 @@ class TestWeaveEvaluationHooks:
         mock_weave_eval_logger = MagicMock(spec=weave.EvaluationLogger)
         mock_score_logger = MagicMock(spec=weave.flow.eval_imperative.ScoreLogger)
         mock_weave_eval_logger.log_prediction.return_value = mock_score_logger
-        hooks.weave_eval_logger = mock_weave_eval_logger
+        hooks.weave_eval_loggers["test_eval_id"] = mock_weave_eval_logger
 
         # When
         await hooks.on_sample_end(sample)
@@ -125,7 +125,7 @@ class TestWeaveEvaluationHooks:
         )
 
         mock_weave_eval_logger = MagicMock(spec=weave.EvaluationLogger)
-        hooks.weave_eval_logger = mock_weave_eval_logger
+        hooks.weave_eval_loggers["test_eval_id"] = mock_weave_eval_logger
 
         # When
         await hooks.on_task_end(task_end)
@@ -154,7 +154,7 @@ class TestWeaveEvaluationHooks:
         mock_weave_eval_logger = MagicMock(spec=weave.EvaluationLogger)
         mock_weave_eval_logger.finish = MagicMock()
         mock_weave_eval_logger._is_finalized = False
-        hooks.weave_eval_logger = mock_weave_eval_logger
+        hooks.weave_eval_loggers["test_eval_id"] = mock_weave_eval_logger
 
         # When
         await hooks.on_run_end(task_end)


### PR DESCRIPTION
## Describe your changes
  - Each task execution now gets its own dedicated logger instance (use `eval_id` as universial identifier)
  - Prevents logger conflicts when running multiple models simultaneously
  - Update all hook methods to use task-specific loggers from the dictionary
  - Fix tests to work with new dictionary-based logger storage


## Issue ticket number and link (if applicable)
  Fixes #55 
## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [ ] I have added unit tests to cover any core logic changes
