### PR TITLE
fix(weave): use correct scorer traces when multiple epochs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,15 +28,15 @@
             "console": "integratedTerminal",
             "args": [ // add whatever args you want to pass to inspect
                 "eval-set",
-                "test.py",
+                "inspect_evals/agentic_misalignment",
                 "--log-dir",
-                "test-hanging",
+                "test-traces",
                 "--model",
-                "openai/gpt-4o-mini,anthropic/claude-sonnet-4-0",
-                "--limit",
-                "20",
+                "openrouter/openai/gpt-4o-mini",
                 "--display",
-                "plain"
+                "plain",
+                "--epochs",
+                "10"
             ],
             "cwd": "${workspaceFolder}",
             "justMyCode": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- Add scorer traces to correct parent sample when running with multiple epochs
+
 ## [v0.1.6](https://pypi.org/project/inspect-wandb/0.1.6/) (23 September 2025)
 
 ### Added

--- a/inspect_wandb/weave/autopatcher.py
+++ b/inspect_wandb/weave/autopatcher.py
@@ -81,9 +81,11 @@ class PatchedScorer:
             sample_calls = [child for child in current_call._children 
                            if hasattr(child, 'attributes') and 
                            child.attributes is not None and
-                           child.attributes.get('sample_id') == state.sample_id]
+                           child.attributes.get('sample_id') == state.sample_id and child.attributes.get("epoch") == state.epoch]
             
             if sample_calls:
+                if len(sample_calls) > 1:
+                    logger.warning(f"Found multiple sample calls for sample {state.sample_id} and epoch {state.epoch}. This could result in an incorrect Weave trace tree.")
                 sample_call = sample_calls[0]
                 # Manually activate this sample call as the context
                 call_context.push_call(sample_call)


### PR DESCRIPTION
## Describe your changes
This PR matches scorer traces to the correct parent sample trace based on epoch as well as sample id

## Issue ticket number and link (if applicable)

Closes #166 

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
- [x] I have updated the CHANGELOG.md with my changes, if necessary
