### PR TITLE
load settings every time enabled is called

### DIFF
--- a/inspect_wandb/config/settings/base.py
+++ b/inspect_wandb/config/settings/base.py
@@ -26,7 +26,12 @@ class InspectWandBBaseSettings(BaseSettings):
     @model_validator(mode="after")
     def validate_project_and_entity(self) -> Self:
         if self.enabled and (not self.project or not self.entity):
-            logger.warning(f"Project and entity must be set if the wandb integrations are enabled. Disabling integrations for this run. {self.project=} {self.entity=}")
+            missing = []
+            if not self.project:
+                missing.append("project")
+            if not self.entity:
+                missing.append("entity")
+            logger.debug(f"WandB integration disabled: missing required field(s): {', '.join(missing)}. Set via environment variables (WANDB_PROJECT, WANDB_ENTITY), wandb settings file, or pyproject.toml.")
             self.enabled = False
         return self
 

--- a/inspect_wandb/models/hooks.py
+++ b/inspect_wandb/models/hooks.py
@@ -37,8 +37,8 @@ class WandBModelHooks(Hooks):
 
     @override
     def enabled(self) -> bool:
-        self._load_settings()
-        assert self.settings is not None
+        # Always reload settings from scratch to pick up any runtime changes
+        self.settings = ModelsSettings.model_validate({})
         return self.settings.enabled
 
     @override

--- a/inspect_wandb/weave/hooks.py
+++ b/inspect_wandb/weave/hooks.py
@@ -34,8 +34,8 @@ class WeaveEvaluationHooks(Hooks):
 
     @override
     def enabled(self) -> bool:
-        self._load_settings()
-        assert self.settings is not None
+        # Always reload settings from scratch to pick up any runtime changes
+        self.settings = WeaveSettings.model_validate({})
         return self.settings.enabled
 
     @override


### PR DESCRIPTION
## Describe your changes

This prevents issues where an early hook firing (in AISI's case when we override an API key) stops subsequent configuration of wandb)

pls lmk if this looks like the right way of solving and I can clean up the final items on the checklist

## Issue ticket number and link (if applicable)

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [ ] I have added unit tests to cover any core logic changes
- [ ] I have updated the CHANGELOG.md with my changes, if necessary
