### PR TITLE
fix(weave): drain pending sample logging before finalizing evaluation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.12.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.6
     hooks:
       - id: ruff
         name: Ruff linter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - Postprocess Task States using Inspect AI's state_jsonable method to show readable dicts instead of showing Python object reprs in Weave.
+- Drain pending per-sample Weave logging tasks before finalizing the evaluation in `on_task_end`, so scores are no longer silently dropped by a race with `log_summary` (`Cannot log score after finish has been called`).
 
 ## [v0.2.3](https://pypi.org/project/inspect-wandb/0.2.3/) (16 March 2026)
 

--- a/inspect_wandb/weave/autopatcher/plan.py
+++ b/inspect_wandb/weave/autopatcher/plan.py
@@ -8,7 +8,9 @@ from inspect_ai.solver._plan import logger
 from inspect_ai._util.registry import registry_info
 
 
-def _postprocess_solver_inputs(inputs: dict[str, TaskState | Generate]) -> dict[str, dict[str, Any]]:
+def _postprocess_solver_inputs(
+    inputs: dict[str, TaskState | Generate],
+) -> dict[str, dict[str, Any]]:
     state = cast(TaskState, inputs["state"])
     return {"state": state_jsonable(state)}
 

--- a/inspect_wandb/weave/autopatcher/scorer.py
+++ b/inspect_wandb/weave/autopatcher/scorer.py
@@ -15,15 +15,15 @@ from inspect_ai.solver import TaskState
 from inspect_ai.solver._task_state import state_jsonable
 
 
-def _postprocess_scorer_inputs(inputs: dict[str, TaskState | Target]) -> dict[str, dict[str, Any] | list[str]]:
+def _postprocess_scorer_inputs(
+    inputs: dict[str, TaskState | Target],
+) -> dict[str, dict[str, Any] | list[str]]:
     state = cast(TaskState, inputs["state"])
     target = cast(Target, inputs["target"])
     return {
-            "state": state_jsonable(state),
-            "target": target.target,
-        }
-
-
+        "state": state_jsonable(state),
+        "target": target.target,
+    }
 
 
 class PatchedScorer(Scorer):

--- a/inspect_wandb/weave/hooks.py
+++ b/inspect_wandb/weave/hooks.py
@@ -45,10 +45,7 @@ class WeaveEvaluationHooks(InspectWandBHooks):
     _weave_initialized: bool = False
     _eval_set: bool = False
     _eval_set_log_dir: str | None = None
-    # Per-sample Weave logging is scheduled fire-and-forget in on_sample_end. We
-    # track the pending tasks per instance (not on the class) so runs don't share
-    # state, and drain them before the evaluation is finalized in on_task_end.
-    _pending_sample_tasks: set["asyncio.Task[None]"]
+    _pending_sample_tasks: set[asyncio.Task[None]]
 
     def __init__(self) -> None:
         super().__init__()
@@ -165,11 +162,8 @@ class WeaveEvaluationHooks(InspectWandBHooks):
         if not self._hooks_enabled:
             return
 
-        # log_summary below finalizes the Weave evaluation, after which no further
-        # scores can be logged. Drain the fire-and-forget per-sample logging tasks
-        # first; otherwise a still-pending alog_score races the finalization and
-        # Weave raises "Cannot log score after finish has been called", silently
-        # dropping scores from the Weave UI (guaranteed on single-sample evals).
+        # Drain pending per-sample logging before log_summary finalizes the
+        # evaluation; otherwise a late alog_score is dropped after finish.
         if self._pending_sample_tasks:
             await asyncio.gather(*self._pending_sample_tasks, return_exceptions=True)
 

--- a/inspect_wandb/weave/hooks.py
+++ b/inspect_wandb/weave/hooks.py
@@ -45,6 +45,14 @@ class WeaveEvaluationHooks(InspectWandBHooks):
     _weave_initialized: bool = False
     _eval_set: bool = False
     _eval_set_log_dir: str | None = None
+    # Per-sample Weave logging is scheduled fire-and-forget in on_sample_end. We
+    # track the pending tasks per instance (not on the class) so runs don't share
+    # state, and drain them before the evaluation is finalized in on_task_end.
+    _pending_sample_tasks: set["asyncio.Task[None]"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._pending_sample_tasks = set()
 
     @override
     async def on_eval_set_start(self, data: EvalSetStart) -> None:
@@ -157,6 +165,14 @@ class WeaveEvaluationHooks(InspectWandBHooks):
         if not self._hooks_enabled:
             return
 
+        # log_summary below finalizes the Weave evaluation, after which no further
+        # scores can be logged. Drain the fire-and-forget per-sample logging tasks
+        # first; otherwise a still-pending alog_score races the finalization and
+        # Weave raises "Cannot log score after finish has been called", silently
+        # dropping scores from the Weave UI (guaranteed on single-sample evals).
+        if self._pending_sample_tasks:
+            await asyncio.gather(*self._pending_sample_tasks, return_exceptions=True)
+
         weave_eval_logger = self.weave_eval_loggers.get(data.eval_id)
         assert weave_eval_logger is not None
 
@@ -217,6 +233,8 @@ class WeaveEvaluationHooks(InspectWandBHooks):
             return
 
         task = asyncio.create_task(self._log_sample_to_weave_async(data))
+        self._pending_sample_tasks.add(task)
+        task.add_done_callback(self._pending_sample_tasks.discard)
         task.add_done_callback(self._handle_weave_task_result)
 
     def _handle_weave_task_result(self, task: asyncio.Task) -> None:

--- a/tests/test_weave/test_autopatcher.py
+++ b/tests/test_weave/test_autopatcher.py
@@ -8,9 +8,19 @@ from typing import Generator
 import pytest
 from unittest.mock import MagicMock, patch
 from .conftest import WeaveTestClient
-from inspect_wandb.weave.autopatcher.scorer import PatchedScorer, _postprocess_scorer_inputs
-from inspect_wandb.weave.autopatcher.plan import _postprocess_solver_inputs, _postprocess_solver_output
-from inspect_ai._util.registry import registry_info, is_registry_object, set_registry_info
+from inspect_wandb.weave.autopatcher.scorer import (
+    PatchedScorer,
+    _postprocess_scorer_inputs,
+)
+from inspect_wandb.weave.autopatcher.plan import (
+    _postprocess_solver_inputs,
+    _postprocess_solver_output,
+)
+from inspect_ai._util.registry import (
+    registry_info,
+    is_registry_object,
+    set_registry_info,
+)
 from inspect_ai.scorer._metric import Score
 
 
@@ -292,7 +302,6 @@ def _make_task_state() -> TaskState:
 
 
 class TestPostprocessSolverInputs:
-
     def test_serializes_task_state(self):
         # Given
         state = _make_task_state()
@@ -320,7 +329,6 @@ class TestPostprocessSolverInputs:
 
 
 class TestPostprocessSolverOutput:
-
     def test_serializes_task_state(self):
         # Given
         state = _make_task_state()
@@ -346,7 +354,6 @@ class TestPostprocessSolverOutput:
 
 
 class TestPostprocessScorerInputs:
-
     def test_serializes_state_and_target(self):
         # Given
         state = _make_task_state()
@@ -383,4 +390,3 @@ class TestPostprocessScorerInputs:
 
         # Then
         assert result["target"] == ["answer1", "answer2"]
-

--- a/tests/test_weave/test_hooks.py
+++ b/tests/test_weave/test_hooks.py
@@ -1,5 +1,6 @@
+import asyncio
 from inspect_ai.log import EvalLog
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from inspect_ai.hooks import SampleEnd, SampleStart, TaskEnd, RunEnd, TaskStart
 from inspect_ai.model import ChatCompletionChoice, ModelOutput, ChatMessageAssistant
 from inspect_ai.log import EvalSample
@@ -535,6 +536,81 @@ class TestConcurrencyOnSampleEnd:
             scorer="test_score", score=1.0
         )
         mock_score_logger.log_score.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_task_end_drains_pending_sample_logging_before_summary(
+        self, task_end_eval_log: EvalLog, test_settings: WeaveSettings
+    ) -> None:
+        """Pending per-sample Weave logging must complete before on_task_end
+        finalizes the evaluation via log_summary. Otherwise the still-pending
+        alog_score races the finalization and Weave raises
+        "Cannot log score after finish has been called", silently dropping
+        scores from the Weave UI (guaranteed on single-sample evals).
+        """
+        hooks = WeaveEvaluationHooks()
+        hooks.settings = test_settings
+        hooks._hooks_enabled = True
+
+        call_order: list[str] = []
+
+        async def _record_alog_score(*args: object, **kwargs: object) -> None:
+            # Yield the event loop so that, without draining, on_task_end's
+            # synchronous log_summary would win the race and finalize first.
+            await asyncio.sleep(0)
+            call_order.append("alog_score")
+
+        mock_score_logger = MagicMock(spec=ScoreLogger)
+        mock_score_logger._has_finished = False
+        mock_score_logger.alog_score = AsyncMock(side_effect=_record_alog_score)
+        mock_score_logger.finish = MagicMock(
+            side_effect=lambda: call_order.append("finish")
+        )
+
+        mock_weave_eval_logger = MagicMock(spec=EvaluationLogger)
+        mock_weave_eval_logger._evaluate_call = MagicMock(spec=Call)
+        mock_weave_eval_logger.log_summary = MagicMock(
+            side_effect=lambda *a, **k: call_order.append("log_summary")
+        )
+
+        hooks.weave_eval_loggers["test_eval_id"] = mock_weave_eval_logger
+        hooks.sample_calls["test_sample_id"] = mock_score_logger
+
+        sample_end = SampleEnd(
+            eval_set_id=None,
+            run_id="test_run_id",
+            eval_id="test_eval_id",
+            sample_id="test_sample_id",
+            sample=EvalSample(
+                id=1,
+                epoch=1,
+                input="test_input",
+                target="test_output",
+                scores={"test_score": Score(value=1.0)},
+                output=ModelOutput(
+                    model="mockllm/model",
+                    choices=[
+                        ChatCompletionChoice(
+                            message=ChatMessageAssistant(content="test_output")
+                        )
+                    ],
+                ),
+            ),
+        )
+        task_end = TaskEnd(
+            eval_set_id=None,
+            run_id="test_run_id",
+            eval_id="test_eval_id",
+            log=task_end_eval_log,
+        )
+
+        # When: sample logging is scheduled fire-and-forget, then the task ends
+        await hooks.on_sample_end(sample_end)
+        await hooks.on_task_end(task_end)
+
+        # Then: the score was logged and its prediction finished before the
+        # evaluation summary was finalized, and no pending tasks remain
+        assert call_order == ["alog_score", "finish", "log_summary"]
+        assert hooks._pending_sample_tasks == set()
 
     @pytest.mark.asyncio
     async def test_background_task_exceptions_handled_properly(


### PR DESCRIPTION
## Describe your changes

`WeaveEvaluationHooks.on_sample_end` schedules per-sample Weave logging fire-and-forget:

```python
task = asyncio.create_task(self._log_sample_to_weave_async(data))
```

`on_task_end` then calls `EvaluationLogger.log_summary`, which finalizes the evaluation and finishes every prediction/score logger. Any sample-logging task still pending at that point calls `alog_score` after finalization, and Weave raises:

```
ValueError: Cannot log score after finish has been called
```

(from `ScoreLogger.alog_score`). Because the logging runs in a fire-and-forget task, the failure is not surfaced to the eval and the affected scores are **silently missing from the Weave UI**. On a single-sample eval this is essentially guaranteed: while integrating inspect-wandb 0.2.3 with google/vertex Inspect evals we saw 5 of 9 scorer values dropped on a one-sample run.

### Fix

Track the created tasks per instance and drain them with `asyncio.gather(...)` at the start of `on_task_end`, before `log_summary` finalizes the evaluation. `on_sample_end` still returns without awaiting, so the non-blocking concurrency is preserved, but every score is now flushed before finalization.

The task set is initialized per instance (in `__init__`) rather than as a class attribute so concurrent runs don't share state and the pending set can't leak between evaluations.

This is independent of #241 (agent tracing): that PR touches `on_task_start` / `on_sample_start` / `on_run_end` and adds `on_sample_event`, not the `on_sample_end` / `on_task_end` finalization path.

### Tests

Added `test_on_task_end_drains_pending_sample_logging_before_summary`, which asserts the per-sample `alog_score`/`finish` complete before `log_summary`. It fails against the current code (summary finalizes first) and passes with the fix.

## Issue ticket number and link (if applicable)

None — found during integration; no existing issue or PR covers it.

## Checklist
- [x] I have run the pre-commit checks (ruff check, ruff format, mypy)
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
- [x] I have updated the CHANGELOG.md with my changes, if necessary
