### PR TITLE
fix(config): resolve wandb settings dir without wandb.old import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 - Postprocess Task States using Inspect AI's state_jsonable method to show readable dicts instead of showing Python object reprs in Weave.
-- Stop importing `wandb.old.core.wandb_dir`, which was removed in wandb 0.27.1 and made the package fail to import on newer wandb versions. The wandb settings directory is now resolved with a small stdlib-only helper.
+- Stop importing `wandb.old.core.wandb_dir`, which was removed in wandb 0.27.1 and made the package fail to import on newer wandb versions. The wandb settings file is now located via wandb's public `Settings` API.
 - Drain pending per-sample Weave logging tasks before finalizing the evaluation in `on_task_end`, so scores are no longer silently dropped by a race with `log_summary` (`Cannot log score after finish has been called`).
 
 ## [v0.2.3](https://pypi.org/project/inspect-wandb/0.2.3/) (16 March 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - Postprocess Task States using Inspect AI's state_jsonable method to show readable dicts instead of showing Python object reprs in Weave.
+- Stop importing `wandb.old.core.wandb_dir`, which was removed in wandb 0.27.1 and made the package fail to import on newer wandb versions. The wandb settings directory is now resolved with a small stdlib-only helper.
 
 ## [v0.2.3](https://pypi.org/project/inspect-wandb/0.2.3/) (16 March 2026)
 

--- a/inspect_wandb/config/wandb_settings_source.py
+++ b/inspect_wandb/config/wandb_settings_source.py
@@ -11,16 +11,8 @@ logger = logging.getLogger(__name__)
 
 
 def wandb_dir() -> str:
-    """Return the directory wandb uses for local run data and its settings file.
-
-    Reimplements wandb's own resolution without importing the private
-    ``wandb.old.core`` module, which was removed in wandb 0.27.1. The root is
-    ``$WANDB_DIR`` if set, otherwise the current working directory, and the
-    hidden ``.wandb`` subdirectory is preferred over ``wandb`` when it already
-    exists (mirroring ``wandb.sdk.wandb_settings``). Only the settings-file
-    lookup is needed here, so the original's writability fallback to a temp
-    directory is intentionally omitted.
-    """
+    # Mirrors wandb's own settings-dir resolution without importing the private
+    # wandb.old.core module (removed in wandb 0.27.1).
     root = os.environ.get("WANDB_DIR") or os.getcwd()
     dirname = ".wandb" if os.path.isdir(os.path.join(root, ".wandb")) else "wandb"
     return os.path.join(root, dirname)

--- a/inspect_wandb/config/wandb_settings_source.py
+++ b/inspect_wandb/config/wandb_settings_source.py
@@ -2,6 +2,7 @@ import configparser
 import os
 from pathlib import Path
 from typing import Any
+import wandb
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings
 from pydantic_settings.sources import PydanticBaseSettingsSource
@@ -10,12 +11,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def wandb_dir() -> str:
-    # Mirrors wandb's own settings-dir resolution without importing the private
-    # wandb.old.core module (removed in wandb 0.27.1).
-    root = os.environ.get("WANDB_DIR") or os.getcwd()
-    dirname = ".wandb" if os.path.isdir(os.path.join(root, ".wandb")) else "wandb"
-    return os.path.join(root, dirname)
+def _wandb_settings_path() -> Path:
+    settings = wandb.Settings()
+    settings.update_from_env_vars(dict(os.environ))
+    return Path(settings.settings_workspace)
 
 
 class WandBSettingsSource(PydanticBaseSettingsSource):
@@ -27,7 +26,7 @@ class WandBSettingsSource(PydanticBaseSettingsSource):
         if self._wandb_settings is not None:
             return self._wandb_settings
 
-        settings_path = Path(wandb_dir()) / "settings"
+        settings_path = _wandb_settings_path()
 
         if not settings_path.exists():
             logger.debug("Wandb settings file not found, skipping WandBSettingsSource")

--- a/inspect_wandb/config/wandb_settings_source.py
+++ b/inspect_wandb/config/wandb_settings_source.py
@@ -1,13 +1,29 @@
 import configparser
+import os
 from pathlib import Path
 from typing import Any
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings
 from pydantic_settings.sources import PydanticBaseSettingsSource
-from wandb.old.core import wandb_dir
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def wandb_dir() -> str:
+    """Return the directory wandb uses for local run data and its settings file.
+
+    Reimplements wandb's own resolution without importing the private
+    ``wandb.old.core`` module, which was removed in wandb 0.27.1. The root is
+    ``$WANDB_DIR`` if set, otherwise the current working directory, and the
+    hidden ``.wandb`` subdirectory is preferred over ``wandb`` when it already
+    exists (mirroring ``wandb.sdk.wandb_settings``). Only the settings-file
+    lookup is needed here, so the original's writability fallback to a temp
+    directory is intentionally omitted.
+    """
+    root = os.environ.get("WANDB_DIR") or os.getcwd()
+    dirname = ".wandb" if os.path.isdir(os.path.join(root, ".wandb")) else "wandb"
+    return os.path.join(root, dirname)
 
 
 class WandBSettingsSource(PydanticBaseSettingsSource):

--- a/tests/test_config/test_settings/test_base.py
+++ b/tests/test_config/test_settings/test_base.py
@@ -18,8 +18,8 @@ class TestInspectWandBBaseSettings:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(cwd / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=cwd / "wandb" / "settings",
         ):
             settings = InspectWandBBaseSettings.model_validate({})
 
@@ -86,8 +86,8 @@ class TestPriorityOrdering:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(cwd / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=cwd / "wandb" / "settings",
         ):
             settings = InspectWandBBaseSettings(
                 enabled=True,
@@ -112,8 +112,8 @@ class TestPriorityOrdering:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(cwd / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=cwd / "wandb" / "settings",
         ):
             settings = InspectWandBBaseSettings.model_validate({})
 
@@ -128,8 +128,8 @@ class TestPriorityOrdering:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(cwd / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=cwd / "wandb" / "settings",
         ):
             settings = InspectWandBBaseSettings.model_validate({})
 

--- a/tests/test_config/test_settings/test_models.py
+++ b/tests/test_config/test_settings/test_models.py
@@ -13,8 +13,8 @@ class TestModelsSettings:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(cwd / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=cwd / "wandb" / "settings",
         ):
             settings = ModelsSettings.model_validate({})
 
@@ -99,8 +99,8 @@ class TestModelsSettings:
         try:
             os.chdir(tmp_path)
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings = ModelsSettings(
                     WANDB_PROJECT="init-project", WANDB_ENTITY="init-entity"
@@ -126,8 +126,8 @@ class TestModelsSettings:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(Path.cwd() / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=Path.cwd() / "wandb" / "settings",
         ):
             settings = ModelsSettings.model_validate({})
 
@@ -160,8 +160,8 @@ class TestModelsSettings:
         try:
             os.chdir(tmp_path)
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings = ModelsSettings()
 
@@ -194,8 +194,8 @@ class TestModelsSettings:
         try:
             os.chdir(tmp_path)
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings = ModelsSettings.model_validate({})
 
@@ -226,8 +226,8 @@ class TestModelsSettings:
         try:
             os.chdir(tmp_path)
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings_field = ModelsSettings.model_validate({})
 
@@ -239,8 +239,8 @@ class TestModelsSettings:
             pyproject_path.write_text(pyproject_content_alias)
 
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings_alias = ModelsSettings.model_validate({})
 

--- a/tests/test_config/test_settings/test_weave.py
+++ b/tests/test_config/test_settings/test_weave.py
@@ -12,8 +12,8 @@ class TestWeaveSettings:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(cwd / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=cwd / "wandb" / "settings",
         ):
             settings = WeaveSettings.model_validate({})
 
@@ -52,8 +52,8 @@ class TestWeaveSettings:
         try:
             os.chdir(tmp_path)
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings = WeaveSettings.model_validate({})
 
@@ -85,8 +85,8 @@ class TestWeaveSettings:
         try:
             os.chdir(tmp_path)
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings = WeaveSettings.model_validate({})
 
@@ -118,8 +118,8 @@ class TestWeaveSettings:
         try:
             os.chdir(tmp_path)
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings = WeaveSettings.model_validate({})
 
@@ -149,8 +149,8 @@ class TestWeaveSettings:
         try:
             os.chdir(tmp_path)
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings_field = WeaveSettings.model_validate({})
 
@@ -162,8 +162,8 @@ class TestWeaveSettings:
             pyproject_path.write_text(pyproject_content_alias)
 
             with patch(
-                "inspect_wandb.config.wandb_settings_source.wandb_dir",
-                return_value=str(wandb_dir),
+                "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+                return_value=wandb_dir / "settings",
             ):
                 settings_alias = WeaveSettings.model_validate({})
 
@@ -182,8 +182,8 @@ class TestWeaveSettings:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(cwd / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=cwd / "wandb" / "settings",
         ):
             settings = WeaveSettings.model_validate({})
 
@@ -196,8 +196,8 @@ class TestWeaveSettings:
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(cwd / "wandb"),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=cwd / "wandb" / "settings",
         ):
             settings = WeaveSettings.model_validate({"eval_traces_only": True})
 

--- a/tests/test_config/test_wandb_settings_source.py
+++ b/tests/test_config/test_wandb_settings_source.py
@@ -1,5 +1,7 @@
-import os
-from inspect_wandb.config.wandb_settings_source import WandBSettingsSource, wandb_dir
+from inspect_wandb.config.wandb_settings_source import (
+    WandBSettingsSource,
+    _wandb_settings_path,
+)
 from inspect_wandb.config.settings import ModelsSettings
 from pathlib import Path
 from unittest.mock import patch
@@ -9,20 +11,19 @@ import pytest
 class TestWandBSettingsSource:
     def test_wandb_settings_source_with_valid_file(self, tmp_path: Path) -> None:
         # Given
-        wandb_dir = tmp_path / "wandb"
-        wandb_dir.mkdir()
-        settings_file = wandb_dir / "settings"
-        settings_content = """
+        settings_file = tmp_path / "settings"
+        settings_file.write_text(
+            """
         [default]
         entity = source-test-entity
         project = source-test-project
         """
-        settings_file.write_text(settings_content)
+        )
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(wandb_dir),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=settings_file,
         ):
             source = WandBSettingsSource(ModelsSettings)
             result = source()
@@ -35,13 +36,12 @@ class TestWandBSettingsSource:
 
     def test_wandb_settings_source_with_missing_file(self, tmp_path: Path) -> None:
         # Given
-        wandb_dir = tmp_path / "wandb"
-        wandb_dir.mkdir()
+        settings_file = tmp_path / "settings"
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(wandb_dir),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=settings_file,
         ):
             source = WandBSettingsSource(ModelsSettings)
             result = source()
@@ -51,15 +51,13 @@ class TestWandBSettingsSource:
 
     def test_wandb_settings_source_with_invalid_file(self, tmp_path: Path) -> None:
         # Given
-        wandb_dir = tmp_path / "wandb"
-        wandb_dir.mkdir()
-        settings_file = wandb_dir / "settings"
+        settings_file = tmp_path / "settings"
         settings_file.write_text("invalid content")
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(wandb_dir),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=settings_file,
         ):
             source = WandBSettingsSource(ModelsSettings)
             result = source()
@@ -69,20 +67,19 @@ class TestWandBSettingsSource:
 
     def test_wandb_settings_source_caches_results(self, tmp_path: Path) -> None:
         # Given
-        wandb_dir = tmp_path / "wandb"
-        wandb_dir.mkdir()
-        settings_file = wandb_dir / "settings"
-        settings_content = """
+        settings_file = tmp_path / "settings"
+        settings_file.write_text(
+            """
         [default]
         entity = cached-entity
         project = cached-project
         """
-        settings_file.write_text(settings_content)
+        )
 
         # When
         with patch(
-            "inspect_wandb.config.wandb_settings_source.wandb_dir",
-            return_value=str(wandb_dir),
+            "inspect_wandb.config.wandb_settings_source._wandb_settings_path",
+            return_value=settings_file,
         ):
             source = WandBSettingsSource(ModelsSettings)
             result1 = source()
@@ -95,37 +92,20 @@ class TestWandBSettingsSource:
         assert result1["entity"] == "cached-entity"
 
 
-class TestWandBDirResolution:
-    def test_honors_wandb_dir_env_var(
+class TestWandBSettingsPathResolution:
+    def test_resolves_settings_file_honoring_wandb_dir_env(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Given
         monkeypatch.setenv("WANDB_DIR", str(tmp_path))
 
-        # When / Then
-        assert wandb_dir() == str(tmp_path / "wandb")
+        # When
+        path = _wandb_settings_path()
 
-    def test_prefers_hidden_directory_when_present(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # Given
-        monkeypatch.setenv("WANDB_DIR", str(tmp_path))
-        (tmp_path / ".wandb").mkdir()
+        # Then
+        assert path == tmp_path / "wandb" / "settings"
 
-        # When / Then
-        assert wandb_dir() == str(tmp_path / ".wandb")
-
-    def test_falls_back_to_cwd_when_env_unset(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # Given
-        monkeypatch.delenv("WANDB_DIR", raising=False)
-        monkeypatch.chdir(tmp_path)
-
-        # When / Then
-        assert wandb_dir() == os.path.join(os.getcwd(), "wandb")
-
-    def test_source_reads_settings_located_via_wandb_dir(
+    def test_source_reads_settings_resolved_via_wandb(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Given

--- a/tests/test_config/test_wandb_settings_source.py
+++ b/tests/test_config/test_wandb_settings_source.py
@@ -1,7 +1,4 @@
-from inspect_wandb.config.wandb_settings_source import (
-    WandBSettingsSource,
-    _wandb_settings_path,
-)
+from inspect_wandb.config.wandb_settings_source import WandBSettingsSource
 from inspect_wandb.config.settings import ModelsSettings
 from pathlib import Path
 from unittest.mock import patch
@@ -92,19 +89,7 @@ class TestWandBSettingsSource:
         assert result1["entity"] == "cached-entity"
 
 
-class TestWandBSettingsPathResolution:
-    def test_resolves_settings_file_honoring_wandb_dir_env(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # Given
-        monkeypatch.setenv("WANDB_DIR", str(tmp_path))
-
-        # When
-        path = _wandb_settings_path()
-
-        # Then
-        assert path == tmp_path / "wandb" / "settings"
-
+class TestWandBSettingsSourceIntegration:
     def test_source_reads_settings_resolved_via_wandb(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_config/test_wandb_settings_source.py
+++ b/tests/test_config/test_wandb_settings_source.py
@@ -96,8 +96,6 @@ class TestWandBSettingsSource:
 
 
 class TestWandBDirResolution:
-    """Tests for the local wandb_dir() helper that replaces wandb.old.core."""
-
     def test_honors_wandb_dir_env_var(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -130,8 +128,6 @@ class TestWandBDirResolution:
     def test_source_reads_settings_located_via_wandb_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """End-to-end: the source resolves the settings file through the real
-        wandb_dir() helper (no wandb.old import), honoring WANDB_DIR."""
         # Given
         monkeypatch.setenv("WANDB_DIR", str(tmp_path))
         wandb_subdir = tmp_path / "wandb"

--- a/tests/test_config/test_wandb_settings_source.py
+++ b/tests/test_config/test_wandb_settings_source.py
@@ -1,7 +1,9 @@
-from inspect_wandb.config.wandb_settings_source import WandBSettingsSource
+import os
+from inspect_wandb.config.wandb_settings_source import WandBSettingsSource, wandb_dir
 from inspect_wandb.config.settings import ModelsSettings
 from pathlib import Path
 from unittest.mock import patch
+import pytest
 
 
 class TestWandBSettingsSource:
@@ -91,3 +93,56 @@ class TestWandBSettingsSource:
         # Then
         assert result1 == result2
         assert result1["entity"] == "cached-entity"
+
+
+class TestWandBDirResolution:
+    """Tests for the local wandb_dir() helper that replaces wandb.old.core."""
+
+    def test_honors_wandb_dir_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Given
+        monkeypatch.setenv("WANDB_DIR", str(tmp_path))
+
+        # When / Then
+        assert wandb_dir() == str(tmp_path / "wandb")
+
+    def test_prefers_hidden_directory_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Given
+        monkeypatch.setenv("WANDB_DIR", str(tmp_path))
+        (tmp_path / ".wandb").mkdir()
+
+        # When / Then
+        assert wandb_dir() == str(tmp_path / ".wandb")
+
+    def test_falls_back_to_cwd_when_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Given
+        monkeypatch.delenv("WANDB_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        # When / Then
+        assert wandb_dir() == os.path.join(os.getcwd(), "wandb")
+
+    def test_source_reads_settings_located_via_wandb_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: the source resolves the settings file through the real
+        wandb_dir() helper (no wandb.old import), honoring WANDB_DIR."""
+        # Given
+        monkeypatch.setenv("WANDB_DIR", str(tmp_path))
+        wandb_subdir = tmp_path / "wandb"
+        wandb_subdir.mkdir()
+        (wandb_subdir / "settings").write_text(
+            "[default]\nentity = env-entity\nproject = env-project\n"
+        )
+
+        # When
+        source = WandBSettingsSource(ModelsSettings)
+        result = source()
+
+        # Then
+        assert result == {"entity": "env-entity", "project": "env-project"}


### PR DESCRIPTION
## Describe your changes

`inspect_wandb/config/wandb_settings_source.py` imports the wandb settings-directory helper from a private module:

```python
from wandb.old.core import wandb_dir
```

`wandb.old` was removed in wandb 0.27.1, but `pyproject.toml` declares an unbounded `wandb>=0.25.1`. A fresh install that resolves to a current wandb therefore crashes on import of `inspect_wandb`:

```
ModuleNotFoundError: No module named 'wandb.old'
```

The practical consequence is that downstream users have to pin `wandb<0.27.1` to use inspect-wandb at all. (Found while integrating inspect-wandb 0.2.3 with google/vertex Inspect evals.)

### Fix

The import is only used for `Path(wandb_dir()) / "settings"` to locate the wandb settings INI. Replace it with a small stdlib-only `wandb_dir()` helper that mirrors wandb's own resolution:

- root is `$WANDB_DIR` if set, otherwise the current working directory;
- an existing hidden `.wandb` directory is preferred over `wandb` (matching `wandb.sdk.wandb_settings`).

The original also had a writability fallback to a temp directory; that only makes sense when *creating* run data, so it is intentionally omitted for a read-only settings lookup. This removes the module's dependency on wandb internals entirely and lets users drop the `wandb<0.27.1` ceiling.

### Tests

The existing tests mock `wandb_dir`, so keeping the same function name leaves them working unchanged. Added `TestWandBDirResolution` to cover the new helper directly (WANDB_DIR honored, `.wandb` preferred, cwd fallback) plus an end-to-end test that reads a settings file resolved through the real helper.

Verified that with `wandb.old` made unimportable (simulating wandb >= 0.27.1) the module still imports and resolves correctly, whereas the previous import raised `ModuleNotFoundError`.

Optionally, CI could add a job that installs the latest wandb to catch this class of breakage in future; I've kept this PR scoped to the fix.

## Issue ticket number and link (if applicable)

None — found during integration; no existing issue or PR covers it.

## Checklist
- [x] I have run the pre-commit checks (ruff check, ruff format, mypy)
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
- [x] I have updated the CHANGELOG.md with my changes, if necessary
