### PR TITLE
feat(weave): de-deduplicate inputs on agent spans

### DIFF
--- a/docs/source/demo-agent-monitoring.md
+++ b/docs/source/demo-agent-monitoring.md
@@ -157,3 +157,9 @@ burn budget. Full intervention support in Inspect WandB is tracked as follow-up 
   rolls up, not lost data: cache-read and cache-write tokens are streamed on every LLM span
   and shown separately in a conversation's **Token breakdown** panel, and the per-span
   input/output/cache figures match Inspect exactly.
+- **Per-turn input is a delta**: each turn's `chat` span carries only the messages *new that
+  turn*, not the whole re-shipped history — this keeps transcript volume linear rather than
+  quadratic on long runs. The full conversation is still reconstructable turn-by-turn, and a
+  context compaction re-ships the (compacted) history in full on the next turn. A consequence:
+  a turn may show only a couple of input messages while its input-token count is large (the
+  model still processed the full, possibly-cached context) — that is expected, not a bug.

--- a/inspect_wandb/weave/sessions.py
+++ b/inspect_wandb/weave/sessions.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from logging import getLogger
 from typing import Any
 
-from inspect_ai.event import Event, ModelEvent, ToolEvent
+from inspect_ai.event import CompactionEvent, Event, ModelEvent, ToolEvent
 from inspect_ai.model import ChatMessage
 from inspect_ai.scorer import Score
 
@@ -92,7 +92,11 @@ def usage_from_event(event: ModelEvent) -> Usage:
 
 
 def llm_span_attributes(
-    event: ModelEvent, *, conversation_id: str, include_content: bool = True
+    event: ModelEvent,
+    *,
+    conversation_id: str,
+    include_content: bool = True,
+    input_from_index: int = 0,
 ) -> dict[str, Any]:
     config = event.config
     output = event.output
@@ -105,7 +109,9 @@ def llm_span_attributes(
         model=event.model,
         provider_name=_provider(event.model),
         conversation_id=conversation_id,
-        input_messages=to_messages(event.input) if include_content else None,
+        input_messages=to_messages(event.input[input_from_index:])
+        if include_content
+        else None,
         output_messages=output_messages if include_content else None,
         usage=usage_from_event(event),
         finish_reasons=[
@@ -226,8 +232,16 @@ class AgentSessionEmitter:
     double-count in the Agents view. A turn is one model generation plus the tool
     calls it triggered; a new ``ModelEvent`` closes the open turn and starts the
     next, and ``finish`` closes the last turn with sample outcome metadata
-    attached. All emission is best-effort: failures are logged and never
-    propagate into the eval run.
+    attached.
+
+    Each ``chat`` span's ``input.messages`` carries only the messages *new that
+    turn* (``event.input`` sliced from the previous turn's length), not the whole
+    re-shipped history — keeping aggregate transcript volume ~O(n) instead of
+    O(n²) on long-horizon runs. Token counts are unchanged (they reflect the real
+    API call). A ``CompactionEvent`` rewrites the message stream, so it resets the
+    slice offset and the next turn re-ships its full (compacted) input. All
+    emission is best-effort: failures are logged and never propagate into the eval
+    run.
     """
 
     def __init__(
@@ -247,6 +261,7 @@ class AgentSessionEmitter:
         self._identity_attributes = _inspect_attributes(identity)
         self._include_content = include_content
         self._turn_index = 0
+        self._prev_input_length = 0
         self._reset_turn()
 
     def _reset_turn(self) -> None:
@@ -268,10 +283,16 @@ class AgentSessionEmitter:
                         event,
                         conversation_id=self._session_id,
                         include_content=self._include_content,
+                        input_from_index=self._prev_input_length,
                     ),
                     _to_nanoseconds(event.timestamp),
                     _to_nanoseconds(event.completed),
                 )
+                self._prev_input_length = len(event.input)
+            elif isinstance(event, CompactionEvent):
+                # History was rewritten; the next model input is a new stream, so
+                # re-ship it in full rather than delta against the old one.
+                self._prev_input_length = 0
             elif isinstance(event, ToolEvent) and self._turn_span is not None:
                 self._emit_child(
                     f"execute_tool {event.function}",

--- a/tests/test_weave/test_sessions.py
+++ b/tests/test_weave/test_sessions.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from inspect_ai.event import ModelEvent, ToolEvent
+from inspect_ai.event import CompactionEvent, ModelEvent, ToolEvent
 from inspect_ai.model import (
     ChatCompletionChoice,
     ChatMessageAssistant,
@@ -67,6 +67,12 @@ def make_tool_event(tool_id: str = "call_1", function: str = "bash") -> ToolEven
     )
 
 
+def make_model_event_with_history(contents: list[str]) -> ModelEvent:
+    event = make_model_event()
+    event.input = [ChatMessageUser(content=text) for text in contents]
+    return event
+
+
 class TestPureBuilders:
     def test_to_messages_maps_roles(self) -> None:
         # Given
@@ -123,6 +129,33 @@ class TestPureBuilders:
         assert "gen_ai.input.messages" not in attributes
         assert "gen_ai.output.messages" not in attributes
         assert attributes["gen_ai.usage.input_tokens"] == 100
+
+    def test_llm_span_attributes_trims_input_to_index(self) -> None:
+        # Given
+        event = make_model_event_with_history(["MSG_A", "MSG_B", "MSG_C"])
+
+        # When
+        attributes = llm_span_attributes(
+            event, conversation_id="sess-1", input_from_index=1
+        )
+
+        # Then
+        serialized_input = attributes["gen_ai.input.messages"]
+        assert "MSG_B" in serialized_input
+        assert "MSG_C" in serialized_input
+        assert "MSG_A" not in serialized_input
+
+    def test_llm_span_attributes_include_content_false_ignores_index(self) -> None:
+        # Given
+        event = make_model_event_with_history(["MSG_A", "MSG_B"])
+
+        # When
+        attributes = llm_span_attributes(
+            event, conversation_id="sess-1", include_content=False, input_from_index=1
+        )
+
+        # Then
+        assert "gen_ai.input.messages" not in attributes
 
     def test_tool_include_content_false_drops_args_and_result(self) -> None:
         # Given
@@ -357,3 +390,68 @@ class TestAgentSessionEmitter:
 
         # Then
         assert recorded == []
+
+    def _chat_inputs(self, recorded: list) -> list[str]:
+        return [
+            attributes.get("gen_ai.input.messages", "")
+            for kind, name, attributes in recorded
+            if name and name.startswith("chat")
+        ]
+
+    def test_input_trimmed_to_delta_across_turns(self) -> None:
+        # Given: turn 1 sends one message, turn 2 re-ships it plus two new ones
+        events = [
+            make_model_event_with_history(["MSG_A"]),
+            make_model_event_with_history(["MSG_A", "MSG_B", "MSG_C"]),
+        ]
+
+        # When
+        first_input, second_input = self._chat_inputs(self._run(events))
+
+        # Then: turn 1 is full (prev=0); turn 2 carries only the new delta
+        assert "MSG_A" in first_input
+        assert "MSG_B" in second_input
+        assert "MSG_C" in second_input
+        assert "MSG_A" not in second_input
+
+    def test_compaction_event_resets_to_full_input(self) -> None:
+        # Given: history is rewritten to a summary between the two turns
+        events = [
+            make_model_event_with_history(["MSG_A", "MSG_B"]),
+            CompactionEvent(type="summary"),
+            make_model_event_with_history(["SUMMARY"]),
+        ]
+
+        # When
+        first_input, second_input = self._chat_inputs(self._run(events))
+
+        # Then: without the reset, prev_len=2 would slice the 1-message input to
+        # empty; the CompactionEvent forces the next turn to re-ship in full
+        assert "MSG_A" in first_input
+        assert "SUMMARY" in second_input
+
+    def test_aggregate_input_volume_is_linear_not_quadratic(self) -> None:
+        # Given: an agent whose history grows by one message each turn, so the
+        # previous input length equals the turn index
+        turns = 20
+        events = [
+            make_model_event_with_history([f"m{i}" for i in range(turn + 1)])
+            for turn in range(turns)
+        ]
+
+        def serialized_input_length(event: ModelEvent, input_from_index: int) -> int:
+            attributes = llm_span_attributes(
+                event, conversation_id="s", input_from_index=input_from_index
+            )
+            return len(attributes["gen_ai.input.messages"])
+
+        # When: comparing the delta (from the previous turn's length) against
+        # re-shipping the full history every turn, using the same serialization
+        delta_volume = sum(
+            serialized_input_length(event, turn) for turn, event in enumerate(events)
+        )
+        full_volume = sum(serialized_input_length(event, 0) for event in events)
+
+        # Then: delta emits ~one message per turn (linear) rather than the whole
+        # history each turn (quadratic)
+        assert delta_volume < full_volume / 5


### PR DESCRIPTION
## Describe your changes

This PR improves the readability and performance of the agent monitoring feature, which currently adds the full Inspect input stream as the input to each turn. this means many messages are repeated many times - this PR only adds the most recent messages as the input to each turn, creating a coherent transcript that follows the agent trajectory without repetition,

## Issue ticket number and link (if applicable)

Closes #242 

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
- [x] I have updated the CHANGELOG.md with my changes, if necessary
